### PR TITLE
feat: agent0frontのタレントプロファイルアプリケーションをfrontendにマージ

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,9 +8,13 @@
       "name": "agent0_rfp",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-slot": "^1.2.3",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
         "next": "15.3.2",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "tailwind-merge": "^3.3.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -979,6 +983,39 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1330,7 +1367,7 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2337,11 +2374,32 @@
         "node": ">=18"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color": {
       "version": "4.2.3",
@@ -2414,7 +2472,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -5743,6 +5801,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
+      "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,9 +9,13 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "next": "15.3.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.3.2"
+    "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -8,8 +8,9 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-inter), var(--font-noto-sans-jp), sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Consolas,
+    "Liberation Mono", Menlo, monospace;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -22,5 +23,267 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-inter), var(--font-noto-sans-jp), sans-serif;
+}
+
+@layer components {
+  .profile-card {
+    background: var(--brand-white);
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1),
+      0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    border: 1px solid var(--brand-light-gray);
+    @apply rounded-lg;
+    height: 100%;
+  }
+
+  .profile-card--contact {
+    background: var(--brand-lighter-blue);
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1),
+      0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    border: 1px solid var(--brand-light-gray);
+    @apply rounded-lg;
+    height: 100%;
+  }
+
+  .card-header-padding {
+    @apply pb-4 px-6 pt-6;
+  }
+
+  .card-title-base {
+    color: var(--brand-dark);
+    @apply text-base font-medium flex items-center gap-2;
+  }
+
+  .icon-base {
+    color: var(--brand-primary);
+    @apply w-5 h-5;
+  }
+
+  .icon-small {
+    color: var(--brand-medium-gray);
+    @apply w-4 h-4;
+  }
+
+  .icon-contact {
+    font-family: "Material Symbols Outlined", sans-serif;
+    font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 20;
+    color: var(--brand-primary);
+    font-size: 12px;
+    width: 20px;
+    height: 20px;
+    background: var(--brand-white);
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-style: normal;
+    line-height: 1;
+    text-transform: none;
+    letter-spacing: normal;
+    word-wrap: normal;
+    white-space: nowrap;
+    direction: ltr;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    -moz-osx-font-smoothing: grayscale;
+    font-feature-settings: "liga";
+  }
+
+  .card-content-padding {
+    @apply px-6 pb-6;
+  }
+
+  .text-secondary {
+    color: var(--brand-medium-gray);
+    @apply text-sm;
+  }
+
+  .text-meta {
+    color: var(--brand-medium-gray);
+    @apply text-xs;
+  }
+
+  .status-dot {
+    background: var(--brand-primary);
+    @apply w-2 h-2 rounded-full;
+  }
+
+  .list-item-base {
+    background: var(--brand-bg);
+    @apply flex items-start gap-3 p-3 rounded-lg;
+  }
+
+  .list-item--hoverable {
+    background: var(--brand-bg);
+    @apply flex items-start gap-3 p-3 rounded-lg transition-colors;
+  }
+
+  .list-item--hoverable:hover {
+    background: var(--brand-lighter-blue);
+  }
+
+  .list-item--interactive {
+    background: var(--brand-bg);
+    border: 1px solid transparent;
+    @apply flex items-start gap-3 p-3 rounded-lg transition-colors cursor-pointer;
+  }
+
+  .list-item--interactive:hover {
+    background: var(--brand-light-blue);
+    border-color: var(--brand-primary);
+  }
+
+  .company-title {
+    color: var(--brand-dark);
+    @apply font-semibold;
+  }
+
+  .job-title {
+    color: var(--brand-primary);
+    @apply text-sm font-medium;
+  }
+
+  .department-name {
+    color: var(--brand-medium-gray);
+    @apply text-sm;
+  }
+
+  .person-name {
+    color: var(--brand-dark);
+    @apply font-medium text-sm;
+  }
+
+  .career-section {
+    @apply border-l-4 pl-4 py-2;
+  }
+
+  .career-section--current {
+    border-left-color: #007aff;
+    background: #e6f0ff;
+    @apply border-l-4 pl-4 py-2 rounded-r-lg;
+  }
+
+  .career-section--past {
+    border-left-color: var(--brand-medium-gray);
+    @apply border-l-4 pl-4 py-2;
+  }
+
+  .career-info-container {
+    @apply flex flex-col space-y-1;
+  }
+
+  .profile-header-gradient {
+    background: #007aff;
+    @apply text-white px-12 py-8;
+  }
+
+  /* Brand Color Variables */
+  :root {
+    --brand-primary: #007aff;
+    --brand-light-blue: #d2e4ff;
+    --brand-lighter-blue: #e6f0ff;
+    --brand-bg: #fafafa;
+    --brand-dark: #333333;
+    --brand-medium-gray: #8c8c8c;
+    --brand-light-gray: #d9d9d9;
+    --brand-white: #ffffff;
+  }
+
+  .activity-category--news {
+    background-color: #eaf4ff;
+  }
+
+  .activity-category--news .activity-badge {
+    background-color: white;
+    color: #155b8e;
+    border-color: #155b8e;
+  }
+
+  .activity-category--event {
+    background-color: #fff1e6;
+  }
+
+  .activity-category--event .activity-badge {
+    background-color: white;
+    color: #c25300;
+    border-color: #c25300;
+  }
+
+  .activity-category--book {
+    background-color: #f5f5f0;
+  }
+
+  .activity-category--book .activity-badge {
+    background-color: white;
+    color: #c25300;
+    border-color: #c25300;
+  }
+
+  .activity-category--paper {
+    background-color: #f3f0ff;
+  }
+
+  .activity-category--paper .activity-badge {
+    background-color: white;
+    color: #6041a6;
+    border-color: #6041a6;
+  }
+
+  .activity-category--other {
+    background-color: #ecfdf3;
+  }
+
+  .activity-category--other .activity-badge {
+    background-color: white;
+    color: #2b7a4b;
+    border-color: #2b7a4b;
+  }
+
+  .activity-badge {
+    @apply text-xs px-2 py-0.5 rounded-full border;
+  }
+
+  .material-symbols-outlined {
+    font-family: "Material Symbols Outlined" !important;
+    font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 20;
+    font-style: normal;
+    line-height: 1;
+    text-transform: none;
+    letter-spacing: normal;
+    word-wrap: normal;
+    white-space: nowrap;
+    direction: ltr;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    -moz-osx-font-smoothing: grayscale;
+    font-feature-settings: "liga";
+    -webkit-font-feature-settings: "liga";
+    -moz-font-feature-settings: "liga=1";
+    user-select: none;
+  }
+
+  .material-icon {
+    font-family: "Material Symbols Outlined" !important;
+    font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 20;
+    color: #007aff;
+    font-size: 16px;
+    width: 32px;
+    height: 32px;
+    background: #e6f0ff;
+    border-radius: 4px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-style: normal;
+    line-height: 1;
+    text-transform: none;
+    letter-spacing: normal;
+    word-wrap: normal;
+    white-space: nowrap;
+    direction: ltr;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    -moz-osx-font-smoothing: grayscale;
+    font-feature-settings: "liga";
+  }
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,15 +1,16 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Inter, Noto_Sans_JP } from "next/font/google";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const inter = Inter({
+  variable: "--font-inter",
   subsets: ["latin"],
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const notoSansJP = Noto_Sans_JP({
+  variable: "--font-noto-sans-jp",
   subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
 });
 
 export const metadata: Metadata = {
@@ -23,9 +24,15 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="ja">
+      <head>
+        <link 
+          href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=optional" 
+          rel="stylesheet" 
+        />
+      </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${inter.variable} ${notoSansJP.variable} antialiased`}
       >
         {children}
       </body>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,103 +1,59 @@
-import Image from "next/image";
+import { ProfileHeader } from "@/components/profile/ProfileHeader";
+import { CareerInfo } from "@/components/profile/CareerInfo";
+import { Summary } from "@/components/profile/Summary";
+import { ActivityInfo } from "@/components/profile/ActivityInfo";
+import { ContactInfo } from "@/components/profile/ContactInfo";
+import { StaffList } from "@/components/profile/StaffList";
+import { RelatedPeople } from "@/components/profile/RelatedPeople";
+import { sampleTalentProfile } from "@/data";
 
-export default function Home() {
+export default function TalentProfilePage() {
+  const profile = sampleTalentProfile;
+
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+    <div className="bg-gray-50 min-h-screen">
+      <div className="h-[160px]">
+        <ProfileHeader name={profile.name} skillTags={profile.skillTags} />
+      </div>
+      <div className="p-8 h-full">
+        <div className="grid grid-cols-3 gap-4 min-h-[calc(100vh-160px)]">
+          {/* Left Column - Widest */}
+          <div className="grid grid-cols-1 gap-4 h-full">
+            <div className="row-span-3">
+              <CareerInfo
+                currentInfo={profile.currentInfo}
+                pastBusinessCards={profile.pastBusinessCards}
+              />
+            </div>
+            <div className="row-span-9">
+              <Summary records={profile.interviewRecords} />
+            </div>
+          </div>
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
+          {/* Middle Column - Activity Information */}
+          <div className="grid grid-cols-1 gap-4 h-full">
+            <div className="row-span-12">
+              <ActivityInfo activities={profile.activities} />
+            </div>
+          </div>
+
+          {/* Right Column - Narrowest */}
+          <div className="grid grid-cols-1 gap-4 h-full">
+            <div className="row-span-2">
+              <ContactInfo
+                email={profile.contactInfo.email}
+                phone={profile.contactInfo.phone}
+              />
+            </div>
+            <div className="row-span-5">
+              <StaffList staff={profile.contactStaff} />
+            </div>
+            <div className="row-span-5">
+              <RelatedPeople people={profile.relatedPeople} />
+            </div>
+          </div>
         </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/profile/ActivityInfo.tsx
+++ b/frontend/src/components/profile/ActivityInfo.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Activity, ACTIVITY_CATEGORY_CLASSES } from "@/types";
+
+const getCategoryClass = (category: Activity["category"]) => {
+  return ACTIVITY_CATEGORY_CLASSES[category] || "activity-category--other";
+};
+
+interface ActivityInfoProps {
+  activities: Activity[];
+}
+
+export function ActivityInfo({ activities }: ActivityInfoProps) {
+  const [showActivities, setShowActivities] = useState(false);
+
+  const handleFetchActivities = () => {
+    setShowActivities(true);
+  };
+
+  return (
+    <Card className="profile-card h-full">
+      <CardHeader className="card-header-padding">
+        <div className="flex items-center justify-between">
+          <CardTitle className="card-title-base">
+            <span className="material-icon">rss_feed</span>
+            活動情報
+          </CardTitle>
+          <Button
+            variant="outline"
+            size="sm"
+            className="text-xs px-4 py-1.5 border-blue-300 text-blue-600 hover:bg-blue-50 rounded-full bg-transparent"
+            onClick={handleFetchActivities}
+          >
+            関連情報を取得する
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="card-content-padding space-y-4">
+        {!showActivities ? (
+          <div className="flex items-start justify-center pt-4 px-4">
+            <div
+              className="text-sm text-gray-700 leading-relaxed py-20 bg-gray-50 rounded border border-gray-100 w-full text-center cursor-pointer hover:bg-gray-100 transition-colors duration-200"
+              onClick={handleFetchActivities}
+            >
+              活動情報を取得してください
+            </div>
+          </div>
+        ) : activities.length === 0 ? (
+          <div className="flex items-center justify-center pt-8">
+            <div className="text-sm text-gray-500">活動情報はありません</div>
+          </div>
+        ) : (
+          activities.map((activity, index) => (
+            <div
+              key={index}
+              className={`p-4 rounded-lg ${getCategoryClass(
+                activity.category
+              )}`}
+            >
+              <div className="flex items-start justify-between">
+                <div className="flex-1">
+                  <div className="flex items-center gap-2 mb-1">
+                    <Badge className="activity-badge">
+                      {activity.category}
+                    </Badge>
+                    <span className="text-meta">{activity.date}</span>
+                  </div>
+                  <p className="text-sm text-gray-800 leading-relaxed">
+                    {activity.title}
+                  </p>
+                </div>
+                <div className="bg-white rounded-full px-3 py-1 ml-3 shadow-sm border border-gray-100">
+                  <span className="text-xs text-gray-600">
+                    {activity.details}
+                  </span>
+                </div>
+              </div>
+            </div>
+          ))
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/profile/CareerInfo.tsx
+++ b/frontend/src/components/profile/CareerInfo.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CurrentInfo, PastBusinessCard } from "@/types";
+import { ExpandToggleButton } from "./ExpandToggleButton";
+
+interface CareerInfoProps {
+  currentInfo: CurrentInfo;
+  pastBusinessCards: PastBusinessCard[];
+}
+
+export function CareerInfo({
+  currentInfo,
+  pastBusinessCards,
+}: CareerInfoProps) {
+  const [showPastCareer, setShowPastCareer] = useState(false);
+
+  const togglePastCareer = () => {
+    setShowPastCareer(!showPastCareer);
+  };
+
+  const hasPastCareer = pastBusinessCards.length > 0;
+
+  return (
+    <Card className="profile-card h-full">
+      <CardHeader className="card-header-padding">
+        <CardTitle className="card-title-base">
+          <span className="material-icon">person</span>
+          経歴情報
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="card-content-padding space-y-4">
+        {/* 現在の情報 */}
+        <div className="border rounded-lg p-4 bg-blue-50 border-blue-200">
+          <div className="flex items-center justify-between mb-3">
+            <Badge className="bg-blue-600 text-white text-xs px-2 py-1 rounded">
+              最新
+            </Badge>
+            <div className="flex items-center gap-1 text-blue-600 text-xs">
+              <span className="material-symbols-outlined text-xs">
+                calendar_today
+              </span>
+              <span>名刺取得日：{currentInfo.exchange_date}</span>
+            </div>
+          </div>
+          <h3 className="text-gray-900 font-medium text-base mb-2">
+            {currentInfo.company_name}
+          </h3>
+          <div className="text-sm text-gray-700 leading-relaxed p-3 bg-gray-50 rounded border border-gray-100">
+            <p className="mb-1">{currentInfo.current_department}</p>
+            <p>{currentInfo.current_title}</p>
+          </div>
+        </div>
+
+        {/* 閉じている時の開閉ボタン */}
+        {hasPastCareer && !showPastCareer && (
+          <ExpandToggleButton isExpanded={false} onClick={togglePastCareer} />
+        )}
+
+        {/* 過去の名刺情報 */}
+        {showPastCareer && (
+          <>
+            <div className="space-y-4">
+              {pastBusinessCards.map((card, index) => (
+                <div
+                  key={index}
+                  className="border rounded-lg p-4 bg-white border-gray-200"
+                >
+                  <div className="flex items-start justify-between mb-2">
+                    <h3 className="text-gray-900 font-medium text-base flex-1">
+                      {card.company_name}
+                    </h3>
+                    <div className="flex items-center gap-1 text-blue-600 text-xs flex-shrink-0 ml-2">
+                      <span className="material-symbols-outlined text-xs">
+                        calendar_today
+                      </span>
+                      <span>取得日：{card.exchange_date}</span>
+                    </div>
+                  </div>
+                  <div className="text-sm text-gray-700 leading-relaxed p-3 bg-gray-50 rounded border border-gray-100">
+                    <p className="mb-1">{card.department_at_time}</p>
+                    <p>{card.title_at_time}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {/* 開いている時の開閉ボタン */}
+            <ExpandToggleButton isExpanded={true} onClick={togglePastCareer} />
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/profile/ContactInfo.tsx
+++ b/frontend/src/components/profile/ContactInfo.tsx
@@ -1,0 +1,29 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface ContactInfoProps {
+  email: string;
+  phone: string;
+}
+
+export function ContactInfo({ email, phone }: ContactInfoProps) {
+  return (
+    <Card className="profile-card--contact h-full">
+      <CardHeader className="card-header-padding">
+        <CardTitle className="card-title-base">
+          <span className="material-icon">contact_page</span>
+          連絡先
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="card-content-padding space-y-2">
+        <div className="flex items-center gap-2 text-secondary">
+          <span className="material-icon icon-contact">email</span>
+          {email}
+        </div>
+        <div className="flex items-center gap-2 text-secondary">
+          <span className="material-icon icon-contact">phone</span>
+          {phone}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/profile/ExpandToggleButton.tsx
+++ b/frontend/src/components/profile/ExpandToggleButton.tsx
@@ -1,0 +1,26 @@
+// 共通スタイル定数
+const STYLES = {
+  container: "flex justify-center py-4",
+  button: "flex items-center justify-center text-gray-400 hover:text-gray-600 transition-colors",
+  icon: "material-symbols-outlined text-2xl"
+}
+
+interface ExpandToggleButtonProps {
+  isExpanded: boolean
+  onClick: () => void
+}
+
+export function ExpandToggleButton({ isExpanded, onClick }: ExpandToggleButtonProps) {
+  return (
+    <div className={STYLES.container}>
+      <button
+        onClick={onClick}
+        className={STYLES.button}
+      >
+        <span className={STYLES.icon}>
+          {isExpanded ? 'expand_less' : 'expand_more'}
+        </span>
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/components/profile/InterviewRecordCard.tsx
+++ b/frontend/src/components/profile/InterviewRecordCard.tsx
@@ -1,0 +1,85 @@
+import { Badge } from "@/components/ui/badge"
+import { InterviewRecord } from "@/types"
+
+// 共通スタイル定数
+const STYLES = {
+  card: {
+    base: "border rounded-lg p-6 shadow-sm",
+    latest: "border-blue-200 bg-blue-50",
+    regular: "border-gray-200 bg-white"
+  },
+  dot: "w-2 h-2 bg-blue-600 rounded-full",
+  header: {
+    container: "flex items-center justify-between mb-4",
+    left: "flex items-center gap-2",
+    recordLabel: "text-gray-600 font-medium",
+    dateContainer: "flex items-center gap-1 text-blue-600",
+    dateIcon: "material-symbols-outlined text-sm",
+    dateText: "text-sm font-medium"
+  },
+  title: {
+    container: "mb-4",
+    badge: "bg-blue-600 text-white border-0 px-3 py-1 text-xs font-medium rounded-md mb-3",
+    text: "text-gray-900 font-medium text-base leading-relaxed"
+  },
+  interviewer: {
+    container: "flex items-center gap-2 mb-4",
+    icon: "material-symbols-outlined text-blue-600 text-lg",
+    name: "text-blue-600 font-medium"
+  },
+  content: {
+    header: "flex items-center gap-2 mb-3",
+    icon: "material-symbols-outlined text-gray-500 text-lg",
+    label: "text-gray-600 font-medium",
+    text: "text-sm text-gray-700 leading-relaxed p-3 bg-gray-50 rounded border border-gray-100"
+  }
+}
+
+interface InterviewRecordCardProps {
+  record: InterviewRecord
+}
+
+export function InterviewRecordCard({ record }: InterviewRecordCardProps) {
+  const cardClassName = `${STYLES.card.base} ${
+    record.isLatest ? STYLES.card.latest : STYLES.card.regular
+  }`
+
+  return (
+    <div className={cardClassName}>
+      {/* Header */}
+      <div className={STYLES.header.container}>
+        <div className={STYLES.header.dateContainer} style={{ marginLeft: 'auto' }}>
+          <span className={STYLES.header.dateIcon}>calendar_today</span>
+          <span className={STYLES.header.dateText}>{record.date}</span>
+        </div>
+      </div>
+
+      {/* Title and Badge */}
+      <div className={STYLES.title.container}>
+        {record.isLatest && (
+          <Badge className={STYLES.title.badge}>
+            最新
+          </Badge>
+        )}
+        <h3 className={STYLES.title.text}>{record.title}</h3>
+      </div>
+
+      {/* Interviewer */}
+      <div className={STYLES.interviewer.container}>
+        <span className={STYLES.interviewer.icon}>person</span>
+        <span className={STYLES.interviewer.name}>{record.interviewer}</span>
+      </div>
+
+      {/* Content Header */}
+      <div className={STYLES.content.header}>
+        <span className={STYLES.content.icon}>description</span>
+        <span className={STYLES.content.label}>面談内容要約</span>
+      </div>
+
+      {/* Content */}
+      <div className={STYLES.content.text}>
+        {record.summary}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/profile/ProfileHeader.tsx
+++ b/frontend/src/components/profile/ProfileHeader.tsx
@@ -1,0 +1,26 @@
+import { Badge } from "@/components/ui/badge"
+
+interface ProfileHeaderProps {
+  name: string
+  skillTags: string[]
+}
+
+export function ProfileHeader({ name, skillTags }: ProfileHeaderProps) {
+  return (
+    <div className="profile-header-gradient">
+      <div className="max-w-full">
+        <h1 className="text-2xl font-bold mb-4">{name}</h1>
+        <div className="flex flex-wrap gap-2">
+          {skillTags.map((tag, index) => (
+            <Badge
+              key={index}
+              className="bg-white text-blue-700 border-0 hover:bg-white text-xs px-3 py-1 rounded-full font-normal"
+            >
+              {tag}
+            </Badge>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/profile/RelatedPeople.tsx
+++ b/frontend/src/components/profile/RelatedPeople.tsx
@@ -1,0 +1,27 @@
+import { RelatedPerson } from "@/types";
+import { ListCard } from "@/components/ui/list-card";
+import { PersonListItem } from "@/components/ui/person-list-item";
+
+interface RelatedPeopleProps {
+  people: RelatedPerson[];
+}
+
+export function RelatedPeople({ people }: RelatedPeopleProps) {
+  return (
+    <ListCard
+      title="関連する人物"
+      icon="share"
+      items={people}
+      emptyMessage="関連する人物はいません"
+      fullHeight={true}
+      renderItem={(person) => (
+        <PersonListItem
+          key={(person as RelatedPerson).id}
+          id={(person as RelatedPerson).id}
+          name={(person as RelatedPerson).name}
+          subtitle={(person as RelatedPerson).company}
+        />
+      )}
+    />
+  );
+}

--- a/frontend/src/components/profile/StaffList.tsx
+++ b/frontend/src/components/profile/StaffList.tsx
@@ -1,0 +1,27 @@
+import { ContactStaff } from "@/types"
+import { ListCard } from "@/components/ui/list-card"
+import { PersonListItem } from "@/components/ui/person-list-item"
+
+interface StaffListProps {
+  staff: ContactStaff[]
+}
+
+export function StaffList({ staff }: StaffListProps) {
+  return (
+    <ListCard
+      title="接点職員"
+      icon="groups"
+      items={staff}
+      emptyMessage="接点職員はいません"
+      fullHeight={true}
+      renderItem={(member) => (
+        <PersonListItem
+          key={(member as ContactStaff).id}
+          id={(member as ContactStaff).id}
+          name={(member as ContactStaff).name}
+          subtitle={(member as ContactStaff).department}
+        />
+      )}
+    />
+  )
+}

--- a/frontend/src/components/profile/Summary.tsx
+++ b/frontend/src/components/profile/Summary.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { InterviewRecord } from "@/types";
+import { useState } from "react";
+import { ExpandToggleButton } from "./ExpandToggleButton";
+
+// 共通スタイル定数
+const STYLES = {
+  header: {
+    container: "card-header-padding",
+    title: "card-title-base",
+  },
+  content: {
+    container: "card-content-padding space-y-4",
+    recordsContainer: "space-y-4",
+  },
+  icon: "material-icon",
+};
+
+interface SummaryProps {
+  records: InterviewRecord[];
+}
+
+export function Summary({ records }: SummaryProps) {
+  const [showAllRecords, setShowAllRecords] = useState(false);
+
+  const toggleRecords = () => {
+    setShowAllRecords(!showAllRecords);
+  };
+
+  const latestRecord = records.find((record) => record.isLatest) || records[0];
+  const otherRecords = records.filter((record) => record !== latestRecord);
+  const hasOtherRecords = otherRecords.length > 0;
+
+  return (
+    <Card className="profile-card h-full">
+      <CardHeader className={STYLES.header.container}>
+        <CardTitle className={STYLES.header.title}>
+          <span className={STYLES.icon}>description</span>
+          面談記録
+        </CardTitle>
+      </CardHeader>
+      <CardContent className={STYLES.content.container}>
+        {/* 最新レコードの概要表示 */}
+        {latestRecord && (
+          <div className="space-y-4">
+            <div className="border rounded-lg p-4 bg-blue-50 border-blue-200">
+              <div className="flex items-center justify-between mb-3">
+                <div className="bg-blue-600 text-white text-xs px-2 py-1 rounded">
+                  最新
+                </div>
+                <div className="flex items-center gap-1 text-blue-600 text-sm">
+                  <span className="material-symbols-outlined text-sm">
+                    calendar_today
+                  </span>
+                  <span>{latestRecord.date}</span>
+                </div>
+              </div>
+              <h3 className="text-gray-900 font-medium text-base mb-2">
+                {latestRecord.title}
+              </h3>
+              <div className="flex items-center gap-2 mb-3">
+                <span className="material-symbols-outlined text-blue-600 text-lg">
+                  person
+                </span>
+                <span className="text-blue-600 font-medium">
+                  {latestRecord.interviewer}
+                </span>
+              </div>
+              <div className="text-sm text-gray-700 leading-relaxed p-3 bg-gray-50 rounded border border-gray-100">
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="material-symbols-outlined text-gray-500 text-lg">
+                    description
+                  </span>
+                  <span className="text-gray-600 font-medium">
+                    面談内容要約
+                  </span>
+                </div>
+                {latestRecord.summary}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* 閉じている時の開閉ボタン */}
+        {hasOtherRecords && !showAllRecords && (
+          <ExpandToggleButton isExpanded={false} onClick={toggleRecords} />
+        )}
+
+        {/* その他のレコード */}
+        {showAllRecords && (
+          <>
+            <div className={STYLES.content.recordsContainer}>
+              {otherRecords.map((record) => (
+                <div
+                  key={record.id}
+                  className="border rounded-lg p-4 bg-white border-gray-200"
+                >
+                  <div className="flex items-start justify-between mb-2">
+                    <h3 className="text-gray-900 font-medium text-base flex-1">
+                      {record.title}
+                    </h3>
+                    <div className="flex items-center gap-1 text-blue-600 text-sm flex-shrink-0 ml-2">
+                      <span className="material-symbols-outlined text-sm">
+                        calendar_today
+                      </span>
+                      <span>{record.date}</span>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2 mb-3">
+                    <span className="material-symbols-outlined text-blue-600 text-lg">
+                      person
+                    </span>
+                    <span className="text-blue-600 font-medium">
+                      {record.interviewer}
+                    </span>
+                  </div>
+                  <div className="text-sm text-gray-700 leading-relaxed p-3 bg-gray-50 rounded border border-gray-100">
+                    <div className="flex items-center gap-2 mb-2">
+                      <span className="material-symbols-outlined text-gray-500 text-lg">
+                        description
+                      </span>
+                      <span className="text-gray-600 font-medium">
+                        面談内容要約
+                      </span>
+                    </div>
+                    {record.summary}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {/* 開いている時の開閉ボタン */}
+            <ExpandToggleButton isExpanded={true} onClick={toggleRecords} />
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -1,0 +1,46 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean
+  }) {
+  const Comp = asChild ? Slot : "button"
+
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Button, buttonVariants }

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/frontend/src/components/ui/empty-state.tsx
+++ b/frontend/src/components/ui/empty-state.tsx
@@ -1,0 +1,14 @@
+interface EmptyStateProps {
+  message: string
+  className?: string
+}
+
+export function EmptyState({ message, className = "" }: EmptyStateProps) {
+  return (
+    <div className={`flex items-center justify-center pt-8 ${className}`}>
+      <div className="text-sm text-gray-500">
+        {message}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/list-card.tsx
+++ b/frontend/src/components/ui/list-card.tsx
@@ -1,0 +1,44 @@
+import { ReactNode } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { EmptyState } from "@/components/ui/empty-state"
+
+interface ListCardProps {
+  title: string
+  icon: string
+  items: unknown[]
+  emptyMessage: string
+  renderItem: (item: unknown, index: number) => ReactNode
+  className?: string
+  fullHeight?: boolean
+}
+
+export function ListCard({ 
+  title, 
+  icon, 
+  items, 
+  emptyMessage, 
+  renderItem, 
+  className = "",
+  fullHeight = false 
+}: ListCardProps) {
+  const cardClasses = `profile-card ${fullHeight ? 'h-full flex flex-col' : ''} ${className}`
+  const contentClasses = `card-content-padding space-y-3 ${fullHeight ? 'flex-1' : ''}`
+
+  return (
+    <Card className={cardClasses}>
+      <CardHeader className="card-header-padding">
+        <CardTitle className="card-title-base">
+          <span className="material-icon">{icon}</span>
+          {title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className={contentClasses}>
+        {items.length === 0 ? (
+          <EmptyState message={emptyMessage} />
+        ) : (
+          items.map(renderItem)
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/ui/person-list-item.tsx
+++ b/frontend/src/components/ui/person-list-item.tsx
@@ -1,0 +1,24 @@
+interface PersonListItemProps {
+  id: number | string
+  name: string
+  subtitle: string
+  className?: string
+  onClick?: () => void
+}
+
+export function PersonListItem({ 
+  id, 
+  name, 
+  subtitle, 
+  className = "list-item--interactive",
+  onClick 
+}: PersonListItemProps) {
+  return (
+    <div key={id} className={className} onClick={onClick}>
+      <div className="flex-1">
+        <h4 className="person-name">{name}</h4>
+        <p className="text-meta mt-1">{subtitle}</p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -1,0 +1,116 @@
+import { TalentProfile } from "@/types"
+
+export const sampleTalentProfile: TalentProfile = {
+  name: "鈴木一郎",
+  skillTags: ["GX投資", "スタートアップエコシステム", "脱炭素技術", "技術経営", "ESG投資", "グリーンテック"],
+  currentInfo: {
+    exchange_date: "2025年7月26日",
+    company_name: "GXベンチャーズ株式会社",
+    current_department: "投資部",
+    current_title: "投資マネージャー"
+  },
+  pastBusinessCards: [
+    {
+      exchange_date: "2022年3月15日",
+      company_name: "三菱商事株式会社",
+      department_at_time: "新規事業開発部",
+      title_at_time: "主任"
+    },
+    {
+      exchange_date: "2020年8月10日",
+      company_name: "マッキンゼー・アンド・カンパニー",
+      department_at_time: "コンサルティング部",
+      title_at_time: "アソシエイト"
+    }
+  ],
+  interviewRecords: [
+    {
+      id: 1,
+      date: "2025/07/11",
+      title: "スタートアップエコシステムの現状と政策支援について",
+      interviewer: "田中太郎",
+      summary: "日本のスタートアップエコシステムの現状について詳細な議論を行った。特に、シード段階での資金調達の課題と政策支援制度の活用方法について議論を行った。参考となる、現場での政策実装に向けた具体的な改善点を明確にすることができた。また、海外諸国と比べての日本のあり方、グローバル市場での競争力強化に向けた長期的な施策についても議論した。",
+      isLatest: true
+    },
+    {
+      id: 2,
+      date: "2025/07/05",
+      title: "AI・データ活用推進に向けた長期政策の動向",
+      interviewer: "佐藤花子",
+      summary: "AI分野への長期政策展開と設計の意見について議論。特に規制強化のAI法制等を考慮して、日本企業の競争力向上の観点から業態を分析した。成功事例としての技術力だけでなく、事業化のスピードと市場ニーズへの対応力が重要であることを確認。今後の産業政策において、段階的なリスクマネージャーの体制と、実証実験から事業化への架け橋の在り方について意見交換を行った。",
+      isLatest: false
+    },
+    {
+      id: 3,
+      date: "2025/06/28",
+      title: "カーボンニュートラル実現に向けた投資戦略",
+      interviewer: "山田次郎",
+      summary: "脱炭素技術への投資戦略と政策について議論実施。グリーンエナジー分野での投資戦略を検討。技術的革新性だけでなく、コスト競争力と実用化スピードが投資判断の重要な要素であることを確認した。政府の支援制度について、初期段階のリスクマネージャーの体制と、実証実験から事業化への運営について、国際競争力強化の観点から、長期的な観点も含めて議論を行った。",
+      isLatest: false
+    }
+  ],
+  activities: [
+    {
+      category: "ニュース",
+      date: "2025.12.01",
+      title: "新規事業政策フォーラムでのパネル登壇記録を取得",
+      details: "詳細を見る",
+    },
+    {
+      category: "書籍",
+      date: "2025.12.01",
+      title: "新規事業政策フォーラムでのパネル登壇記録を取得",
+      details: "詳細を見る",
+    },
+    {
+      category: "論文",
+      date: "2025.12.01",
+      title: "新規事業政策フォーラムでのパネル登壇記録を取得",
+      details: "詳細を見る",
+    },
+    {
+      category: "イベント",
+      date: "2025.12.01",
+      title: "新規事業政策フォーラムでのパネル登壇記録を取得",
+      details: "詳細を見る",
+    },
+  ],
+  contactStaff: [
+    {
+      id: 1,
+      name: "田中太郎",
+      department: "デジタル政策課"
+    },
+    {
+      id: 2,
+      name: "佐藤花子",
+      department: "AI・データ戦略室"
+    },
+    {
+      id: 3,
+      name: "山田次郎",
+      department: "環境・エネルギー政策課"
+    }
+  ],
+  relatedPeople: [
+    {
+      id: 1,
+      name: "田中智子",
+      company: "テックソリューションズ株式会社"
+    },
+    {
+      id: 2,
+      name: "山田浩一",
+      company: "株式会社グリーンエナジー"
+    },
+    {
+      id: 3,
+      name: "佐藤美咲",
+      company: "ヘルスケアAI株式会社"
+    }
+  ],
+  contactInfo: {
+    email: "suzuki@gx-ventures.co.jp",
+    phone: "03-6234-5678"
+  }
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,73 @@
+export interface CurrentInfo {
+  exchange_date: string | null
+  company_name: string
+  current_department: string
+  current_title: string
+}
+
+export interface PastBusinessCard {
+  exchange_date: string
+  company_name: string
+  department_at_time: string
+  title_at_time: string
+}
+
+export interface InterviewRecord {
+  id: number
+  date: string
+  title: string
+  interviewer: string
+  summary: string
+  isLatest: boolean
+}
+
+export interface Activity {
+  category: "ニュース" | "書籍" | "論文" | "イベント"
+  date: string
+  title: string
+  details: string
+}
+
+// 汎用的な人物の基本型
+export interface BasePerson {
+  id: number
+  name: string
+}
+
+// 接点職員型
+export interface ContactStaff extends BasePerson {
+  department: string
+}
+
+// 関連する人物型
+export interface RelatedPerson extends BasePerson {
+  company: string
+}
+
+// 汎用的な人物項目型（ListCardで使用）
+export interface PersonItem extends BasePerson {
+  subtitle: string
+}
+
+// UI用のカテゴリマッピング
+export const ACTIVITY_CATEGORY_CLASSES = {
+  "ニュース": "activity-category--news",
+  "イベント": "activity-category--event", 
+  "書籍": "activity-category--book",
+  "論文": "activity-category--paper",
+} as const
+
+export interface TalentProfile {
+  name: string
+  skillTags: string[]
+  currentInfo: CurrentInfo
+  pastBusinessCards: PastBusinessCard[]
+  interviewRecords: InterviewRecord[]
+  activities: Activity[]
+  contactStaff: ContactStaff[]
+  relatedPeople: RelatedPerson[]
+  contactInfo: {
+    email: string
+    phone: string
+  }
+}


### PR DESCRIPTION
- agent0frontから完全なタレントプロファイルUIコンポーネントを追加
- ProfileHeader、CareerInfo、Summary、ActivityInfo、ContactInfo、StaffList、RelatedPeopleコンポーネントを統合
- 必要なUIライブラリ依存関係を追加（@radix-ui/react-slot、class-variance-authority、clsx、tailwind-merge）
- 日本語フォントとMaterial Iconsをサポートするようにレイアウトとスタイリングを更新
- タレントプロファイル用の包括的なデータタイプとサンプルデータを追加
- リストコンポーネントのTypeScript型の問題を修正
- ビルドとLintの適合性を確保

🤖 Generated with [Claude Code](https://claude.ai/code)